### PR TITLE
update quickstart script to install subgraph dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "pnpm clean && docker compose up --renew-anon-volumes",
     "clean": "docker compose down --volumes",
-    "quickstart": "pnpm contracts:deploy && pnpm subgraph:create && pnpm subgraph:deploy && cd contracts && pnpm mint",
+    "quickstart": "pnpm contracts:deploy && cd subgraph && pnpm install && cd ../ && pnpm subgraph:create && pnpm subgraph:deploy && cd contracts && pnpm mint",
     "contracts:deploy": "cd contracts && pnpm deploy:localhost",
     "subgraph:create": "cd subgraph && pnpm create:local",
     "subgraph:deploy": "cd subgraph && pnpm build && pnpm deploy:local"


### PR DESCRIPTION
I found that if you allow the subgraph directory to install its dependencies prior to deploying the subgraph if you have made changes to the contract, that when you call `pnpm quickstart`, it will successfully rebuild as intended (as opposed to deleting files manually like in the [tutorial](https://www.youtube.com/watch?v=zsa0irrs27M&ab_channel=AustinGriffith).